### PR TITLE
Fix SSH authentication in cleanup preview workflow

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -37,7 +37,9 @@ jobs:
           eval $(ssh-agent -s)
           echo "${{ secrets.PREVIEW_KEY }}" | ssh-add -
           mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/known_hosts
           
           # Clone the preview repository to check what needs cleanup
           git clone git@github.com:wafer-space/preview.wafer.space.git preview-repo

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -30,17 +30,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       
-      - name: Setup SSH for preview repository access
+      - name: Setup SSH and clone preview repository
+        id: find-cleanup
         run: |
           # Setup SSH for accessing the preview repository
           eval $(ssh-agent -s)
           echo "${{ secrets.PREVIEW_KEY }}" | ssh-add -
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts
-      
-      - name: Clone preview repository and find directories to clean
-        id: find-cleanup
-        run: |
+          
           # Clone the preview repository to check what needs cleanup
           git clone git@github.com:wafer-space/preview.wafer.space.git preview-repo
           cd preview-repo


### PR DESCRIPTION
## Summary
Fixes the SSH authentication issue preventing the cleanup workflow from accessing the preview repository.

## Problem
The cleanup workflow was failing with:
```
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
```

## Root Cause
The `ssh-agent` doesn't persist between workflow steps. The SSH setup was in one step and the git clone was in another, so by the time the clone ran, the SSH key was no longer available.

## Solution
Combined the SSH setup and git clone into a single step, matching the pattern used in the `pr-preview.yml` workflow which works correctly.

## Testing
The workflow can be manually triggered to verify the fix works.

Fixes #26

🤖 Generated with [Claude Code](https://claude.ai/code)