### PR TITLE
Fix: Make workflows reliably determine PR commit hashes

### DIFF
--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -62,48 +62,30 @@ jobs:
             console.log(`PR Number: ${prNumber}`);
             console.log(`Preview URL: ${previewUrl}`);
             
-            // Fetch current PR data from GitHub API to get the latest commit hash
+            // Always fetch current PR data from GitHub API to get the latest commit hash
             // This avoids issues with stale data in context.payload after force pushes
-            try {
-              const { data: pullRequest } = await github.rest.pulls.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                pull_number: prNumber
-              });
-              
-              const currentHeadSha = pullRequest.head.sha;
-              const prTitle = pullRequest.title;
-              
-              console.log(`PR Title: ${prTitle}`);
-              console.log(`Current HEAD SHA from API: ${currentHeadSha}`);
-              console.log(`Original HEAD SHA from payload: ${context.payload.pull_request.head.sha}`);
-              
-              if (currentHeadSha !== context.payload.pull_request.head.sha) {
-                console.log(`⚠️  Detected stale commit hash in payload - using current API data`);
-              }
-              
-              // Set outputs for subsequent steps using current API data
-              core.setOutput('pr_number', prNumber);
-              core.setOutput('preview_url', previewUrl);
-              core.setOutput('pr_title', prTitle);
-              core.setOutput('head_sha', currentHeadSha);
-              
-            } catch (error) {
-              console.error(`Failed to fetch current PR data: ${error.message}`);
-              console.log(`Falling back to payload data`);
-              
-              // Fallback to payload data if API call fails
-              const prTitle = context.payload.pull_request.title;
-              const headSha = context.payload.pull_request.head.sha;
-              
-              console.log(`PR Title: ${prTitle}`);
-              console.log(`HEAD SHA from payload: ${headSha}`);
-              
-              core.setOutput('pr_number', prNumber);
-              core.setOutput('preview_url', previewUrl);
-              core.setOutput('pr_title', prTitle);
-              core.setOutput('head_sha', headSha);
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+            
+            const currentHeadSha = pullRequest.head.sha;
+            const prTitle = pullRequest.title;
+            
+            console.log(`PR Title: ${prTitle}`);
+            console.log(`Current HEAD SHA from API: ${currentHeadSha}`);
+            console.log(`Original HEAD SHA from payload: ${context.payload.pull_request.head.sha}`);
+            
+            if (currentHeadSha !== context.payload.pull_request.head.sha) {
+              console.log(`⚠️  Detected stale commit hash in payload - using current API data`);
             }
+            
+            // Set outputs for subsequent steps using current API data
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('preview_url', previewUrl);
+            core.setOutput('pr_title', prTitle);
+            core.setOutput('head_sha', currentHeadSha);
       
       - name: Wait for preview deployment to complete
         if: steps.pr-info.outputs.pr_number

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -55,21 +55,55 @@ jobs:
               return;
             }
             
-            // Handle pull_request trigger
+            // Handle pull_request trigger - fetch current PR state from API to avoid stale data
             const prNumber = context.payload.pull_request.number;
             const previewUrl = `https://preview.wafer.space/pr-${prNumber}/`;
-            const prTitle = context.payload.pull_request.title;
-            const headSha = context.payload.pull_request.head.sha;
             
             console.log(`PR Number: ${prNumber}`);
             console.log(`Preview URL: ${previewUrl}`);
-            console.log(`PR Title: ${prTitle}`);
             
-            // Set outputs for subsequent steps
-            core.setOutput('pr_number', prNumber);
-            core.setOutput('preview_url', previewUrl);
-            core.setOutput('pr_title', prTitle);
-            core.setOutput('head_sha', headSha);
+            // Fetch current PR data from GitHub API to get the latest commit hash
+            // This avoids issues with stale data in context.payload after force pushes
+            try {
+              const { data: pullRequest } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber
+              });
+              
+              const currentHeadSha = pullRequest.head.sha;
+              const prTitle = pullRequest.title;
+              
+              console.log(`PR Title: ${prTitle}`);
+              console.log(`Current HEAD SHA from API: ${currentHeadSha}`);
+              console.log(`Original HEAD SHA from payload: ${context.payload.pull_request.head.sha}`);
+              
+              if (currentHeadSha !== context.payload.pull_request.head.sha) {
+                console.log(`⚠️  Detected stale commit hash in payload - using current API data`);
+              }
+              
+              // Set outputs for subsequent steps using current API data
+              core.setOutput('pr_number', prNumber);
+              core.setOutput('preview_url', previewUrl);
+              core.setOutput('pr_title', prTitle);
+              core.setOutput('head_sha', currentHeadSha);
+              
+            } catch (error) {
+              console.error(`Failed to fetch current PR data: ${error.message}`);
+              console.log(`Falling back to payload data`);
+              
+              // Fallback to payload data if API call fails
+              const prTitle = context.payload.pull_request.title;
+              const headSha = context.payload.pull_request.head.sha;
+              
+              console.log(`PR Title: ${prTitle}`);
+              console.log(`HEAD SHA from payload: ${headSha}`);
+              
+              core.setOutput('pr_number', prNumber);
+              core.setOutput('preview_url', previewUrl);
+              core.setOutput('pr_title', prTitle);
+              core.setOutput('head_sha', headSha);
+            }
       
       - name: Wait for preview deployment to complete
         if: steps.pr-info.outputs.pr_number

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -78,8 +78,16 @@ jobs:
             console.log(`Original HEAD SHA from payload: ${context.payload.pull_request.head.sha}`);
             
             if (currentHeadSha !== context.payload.pull_request.head.sha) {
-              console.log(`⚠️  Detected stale commit hash in payload - using current API data`);
+              console.log(`⚠️  Detected stale commit hash in payload`);
+              console.log(`Payload hash: ${context.payload.pull_request.head.sha}`);
+              console.log(`Current hash: ${currentHeadSha}`);
+              console.log(`A newer commit has been pushed - aborting this workflow run`);
+              console.log(`A new workflow run should be triggered for the newer commit`);
+              core.setFailed('Workflow aborted due to stale commit hash - newer commit detected');
+              return;
             }
+            
+            console.log(`✅ Commit hash is current - proceeding with verification`);
             
             // Set outputs for subsequent steps using current API data
             core.setOutput('pr_number', prNumber);

--- a/test-workflow-abort.md
+++ b/test-workflow-abort.md
@@ -3,3 +3,4 @@
 This file is used to test the workflow abort logic when stale commit hashes are detected.
 
 Test 1: Initial commit to trigger workflow
+Test 2: Second commit to create stale hash scenario

--- a/test-workflow-abort.md
+++ b/test-workflow-abort.md
@@ -1,0 +1,5 @@
+# Test Workflow Abort Logic
+
+This file is used to test the workflow abort logic when stale commit hashes are detected.
+
+Test 1: Initial commit to trigger workflow


### PR DESCRIPTION
## Summary

- Fix preview verification workflow to fetch current PR head SHA from GitHub API instead of relying on potentially stale event payload data
- Abort workflow runs when stale commit hash is detected to prevent wasting resources
- Ensure only verification runs for the current commit proceed

## Problem

The verification workflow was using `context.payload.pull_request.head.sha` which becomes stale after force pushes, causing verification failures when comparing against actually deployed commits.

## Solution

1. Always fetch current PR data from GitHub API using `github.rest.pulls.get()`
2. Compare payload hash with current API hash
3. Abort workflow if hashes differ (indicates a newer commit has been pushed)
4. Only proceed with verification for current commits

## Test Plan

- [x] Test abort logic with force push scenario
- [ ] Verify existing failing PRs now pass verification
- [ ] Monitor workflow behavior in production

🤖 Generated with [Claude Code](https://claude.ai/code)