### PR TITLE
Update website with silicon manufacturing campaign content

### DIFF
--- a/index.html
+++ b/index.html
@@ -564,15 +564,15 @@ subscribe_area:
         <div class="space40"></div>
         <div class="row">
           <div class="col-lg-8 mx-auto">
-            <div id="accordion-1" class="accordion-wrapper">
+            <div id="accordion-1" class="accordion accordion-wrapper">
               {% for item in page.faq_section.questions %}
-              <div class="card shadow">
-                <div class="card-header">
-                  <h3>
-                    <button class="btn collapsed" data-toggle="collapse" data-target="#collapse-1-{{forloop.index}}">{{item.question}}</button>
-                  </h3>
+              <div class="accordion-item card shadow">
+                <div class="accordion-header card-header" id="accordion-heading-1-{{forloop.index}}">
+                  <h5>
+                    <button class="collapsed" data-bs-toggle="collapse" data-bs-target="#accordion-collapse-1-{{forloop.index}}" aria-expanded="false" aria-controls="accordion-collapse-1-{{forloop.index}}">{{item.question}}</button>
+                  </h5>
                 </div>
-                <div id="collapse-1-{{forloop.index}}" class="collapse" data-parent="#accordion-1">
+                <div id="accordion-collapse-1-{{forloop.index}}" class="accordion-collapse collapse" aria-labelledby="accordion-heading-1-{{forloop.index}}" data-bs-parent="#accordion-1">
                   <div class="card-body">
                     <p>{{item.answer}}</p>
                   </div>

--- a/index.html
+++ b/index.html
@@ -45,54 +45,59 @@ features_area:
 # Part of the features_area
 two_columns_one:
   enable: true
-  title: "Why Choose Us?"
-  sub_title: "Why is Search Engine Optimization important for your business?"
+  title: "Who Is It For?"
+  sub_title: "Turn your designs into real silicon that you can hold, probe, and ship to users"
   image: "assets/images/concept/concept8@2x.webp"
   description: |
-    Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Cras justo odio, dapibus ac facilisis in, egestas eget quam. Praesent commodo cursus magna, vel scelerisque nisl consectetur et. Maecenas sed diam eget risus varius blandit sit.
+    wafer.space brings the pooled fabrication model to silicon, just like OSH Park did for PCBs. Predictable pricing, frequent runs, and no-nonsense logistics.
   lists:
-    - "Aenean eu leo quam ornare."
-    - "Nullam quis risus eget mollis."
-    - "Donec elit non mi porta gravida."
-    - "Fusce dapibus cursus commodo."
+    - "Educators & Students: Turn semester projects into real silicon"
+    - "Makers & Independent Developers: Build custom chips and accelerators"
+    - "Startups & Research Labs: Validate feasibility with tangible parts"
+    - "Hardware Engineers: Move beyond FPGA/MCU protos to custom silicon"
 
 # Part of the features_area
 process_area:
   enable: true
-  title: "Our Process"
-  sub_title: "We bring solutions to make life easier for our customers"
+  title: "How It Works"
+  sub_title: "Simple, straightforward path from design to silicon"
   image: "assets/images/concept/concept1@2x.webp"
   lists:
 
-    - title: "Collect Ideas"
-      description: "Nulla vitae elit libero, a pharetra augue. Donec id elit non mi porta gravida at eget metus. Cras justo."
-      icon: "jam jam-lightbulb"
+    - title: "Reserve Your Slot"
+      description: "Secure your ~20 mm² design slot during the campaign. Fixed pricing, no surprises."
+      icon: "jam jam-ticket"
       icon_color: "blue"
 
-    - title: "Data Analysis"
-      description: "Nulla vitae elit libero, a pharetra augue. Donec id elit non mi porta gravida at eget metus. Cras justo."
-      icon: "jam jam-search-folder"
+    - title: "Design & Verify"
+      description: "Use the open GF180MCU PDK with your preferred flow. Run DRC/LVS/ERC sign-off checks."
+      icon: "jam jam-cpu"
       icon_color: "teal"
 
-    - title: "Magic Touch"
-      description: "Nulla vitae elit libero, a pharetra augue. Donec id elit non mi porta gravida at eget metus. Cras justo."
-      icon: "jam jam-heart"
+    - title: "Submit & Fabricate"
+      description: "Submit your tape-in bundle. Your design rides with peers on a pooled wafer run."
+      icon: "jam jam-upload"
+      icon_color: "green"
+
+    - title: "Receive Your Dies"
+      description: "Get ~1,000 bare dies delivered. Optional packaging available via third parties."
+      icon: "jam jam-box"
       icon_color: "yellow"
 
 # Part of the features_area
 two_columns_two:
   enable: true
-  title: "Our Personalized Solutions"
-  sub_title: "Just sit and relax while we take care of your business needs"
+  title: "Features & Specifications"
+  sub_title: "GlobalFoundries GF180MCU - Mature, well-documented process"
   image: "assets/images/concept/concept3@2x.webp"
   description: |
-    Morbi leo risus, porta ac consectetur ac, vestibulum at eros. Cras mattis consectetur purus sit amet fermentum. Vestibulum id ligula porta felis euismod semper. Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.
+    Get access to a mature 180nm mixed-signal process with comprehensive documentation. Perfect for mixed-signal designs, MCUs, sensors, and more. Works with both open-source and proprietary design flows.
 
   lists:
-    - "Aenean eu leo quam ornare."
-    - "Nullam quis risus eget mollis."
-    - "Donec elit non mi porta gravida."
-    - "Fusce dapibus cursus commodo."
+    - "5 metal layers for flexible routing"
+    - "MIM capacitor Type-B (~2.0 fF/µm²)"
+    - "Poly and high-res poly (HRES) resistors"
+    - "Standard-Vt core and I/O devices per PDK"
 
 testimonials:
   enable: false
@@ -132,37 +137,44 @@ testimonials:
 
 pricing_table:
   enable: true
-  title: "Planned Pricing and Configuration"
+  title: "Pricing"
   sub_title: |
-    We're still working on the details of our silicon offering.
-  btn_url: "#"
+    Simple, transparent pricing for real silicon
+  btn_url: "#subscribe"
   description: |
-    <p>The values shown here represent our <em>target range</em>, but they're not guaranteed and may change as we lock in specifics.</p>
-    <p>There will be a single offering which is expected to look similar to <a href="">the Google GF180MCU OpenMPW configuration</a>.</p>
-    <p><em>Unlike</em> the Google program, people will get back raw unpackaged silicon die and thus not requiring the usage of a specific pad frame or Caravel.</p>
-    <p>Packaging <em>may</em> be through a third party at an additional cost.</p>
+    <p><strong>$7,000 USD for ~1,000 parts</strong></p>
+    <p>Flat price per ~20 mm² design slot on a pooled GF180MCU run. Returns ~1,000 bare dies (typical; yield and scribe affect final count).</p>
+    <p>Need more dies? Purchase multiple slots and submit your design multiple times.</p>
+    <p><strong>Optional Services:</strong> Packaging (chip-on-board, QFN wirebond), test services, and IP blocks available through partners.</p>
   plans:
-    - title: "Lowest"
-      monthly_price: "6,000"
+    - title: "Standard Slot"
+      monthly_price: "7,000"
       monthly_currency: "USD"
-      pricing_url: "#"
+      pricing_url: "#subscribe"
       icon: "assets/images/icons/ec-mobile.webp"
       features:
         - "<strong><a href='https://gf180mcu-pdk.readthedocs.io/'>GF180MCU</a></strong> Process"
-        - "<strong>~20mm<sup>2</sup></strong> silicon"
-        - "3.88mm x 5.07mm die size"
-        - "500 to 1,000 raw dies"
+        - "<strong>~20mm<sup>2</sup></strong> silicon area"
+        - "≈ 3.88 × 5.07 mm die size"
+        - "<strong>~1,000 bare dies</strong> delivered"
+        - "Top metal available for pads/inductors"
+        - "Bring your own pad ring and ESD"
 
-    - title: "Highest"
-      monthly_price: "8,000"
-      monthly_currency: "USD"
-      pricing_url: "#"
-      icon: "assets/images/icons/ec-store.webp"
-      features:
-        - "<strong><a href='https://gf180mcu-pdk.readthedocs.io/'>GF180MCU</a></strong> Process"
-        - "<strong>~20mm<sup>2</sup></strong> silicon"
-        - "3.88mm x 5.07mm die size"
-        - "500 to 1,000 raw dies"
+faq_section:
+  enable: true
+  title: "Frequently Asked Questions"
+  sub_title: "Common questions about our silicon manufacturing service"
+  questions:
+    - question: "Do I have to open-source my design?"
+      answer: "No. The PDK is open; your design can be open or closed."
+    - question: "Can you help me with a pad ring?"
+      answer: "No, but the community has created example pad-rings and review for common pitfalls."
+    - question: "How many I/O pads can I use?"
+      answer: "Depends on your pad pitch and die edge budget. Many designs fit 40–120 bonds comfortably in ~20 mm²."
+    - question: "Can I put multiple test chips or multiple macros in one slot?"
+      answer: "Allowed. You own the full ~20 mm²."
+    - question: "Where will my chips be made?"
+      answer: "Fabricated on GF180MCU in Singapore. Logistics and dicing via qualified partners. Final shipping from Singapore or our fulfillment partner."
 
 about_us:
   enable: true
@@ -170,7 +182,7 @@ about_us:
   sub_title: "If you got any questions, don't hesitate to get in touch with us."
   image: "assets/images/concept/concept12@2x.webp"
   description: |
-    
+
   button_text: "Contact Us"
   button_url: "mailto:info@wafer.space"
   bottom_image: "assets/images/art/rocket1.webp"
@@ -535,6 +547,43 @@ subscribe_area:
       {% if page.pricing_table.enable %}
       {% include pricing.html %}
       {% endif %}<!-- pricing_data.enable -->
+
+      {% if page.faq_section.enable %}
+      <div class="faq-wrapper">
+        <div class="space140"></div>
+        <div class="row">
+          <div class="col-md-7 mx-auto">
+            {% if page.faq_section.title %}
+             <h2 class="title-color color-gray text-center mb-30">{{page.faq_section.title}}</h2>
+            {% endif %}
+            {% if page.faq_section.sub_title %}
+             <h3 class="display-3 text-center">{{page.faq_section.sub_title}}</h3>
+            {% endif %}
+          </div>
+        </div>
+        <div class="space40"></div>
+        <div class="row">
+          <div class="col-lg-8 mx-auto">
+            <div id="accordion-1" class="accordion-wrapper">
+              {% for item in page.faq_section.questions %}
+              <div class="card shadow">
+                <div class="card-header">
+                  <h3>
+                    <button class="btn collapsed" data-toggle="collapse" data-target="#collapse-1-{{forloop.index}}">{{item.question}}</button>
+                  </h3>
+                </div>
+                <div id="collapse-1-{{forloop.index}}" class="collapse" data-parent="#accordion-1">
+                  <div class="card-body">
+                    <p>{{item.answer}}</p>
+                  </div>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endif %}<!-- page.faq_section.enable -->
 
     </div>
   </div>

--- a/story.html
+++ b/story.html
@@ -1,0 +1,287 @@
+---
+layout: default
+title: "The Story - wafer.space"
+sub_title: |
+  How we're making silicon accessible
+header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
+
+story_content:
+  enable: true
+  title: "The Story"
+  intro: |
+    It has never been easier to **design your own integrated circuit**. What's missing is an affordable, straightforward path to real silicon that **yields enough parts** to build real products. For **US$7,000**, wafer.space delivers **1,000 raw dies** so you can prototype, test, and ship.
+
+    **wafer.space** makes fabrication straightforward: a pooled run on GlobalFoundries' open **GF180MCU** process in Singapore. You get **20 mm²** on the wafer and **1,000 raw dies back** — that's **US$7 per part**. Packaging is optional via recommended third parties. No gimmicks. Just silicon.
+
+    GF180MCU is a mature, well‑documented, open PDK—great for mixed‑signal, MCUs, sensors, and more—and works with both open‑source and proprietary design flows.
+
+personas:
+  enable: true
+  title: "Who this is for"
+  sub_title: "and what changes for them"
+  list:
+    - name: "Aisha, grad student"
+      description: "She tapes out a mixed‑signal IC for her paper and gets **1,000 dies** for characterization and follow‑up experiments and sharing with other interested researchers."
+      icon: "jam jam-graduation-cap"
+      icon_color: "blue"
+
+    - name: "Priya, instructor"
+      description: "**1,000 parts** means real lab kits; each team gets its own dies for bring‑up, not just a shared demo."
+      icon: "jam jam-users"
+      icon_color: "green"
+
+    - name: "Rowan, hardware hacker"
+      description: "Hobby builds become real hardware: **1,000 dies** enable multiple board spins, community kits, and rapid iteration—packaging optional via OSAT."
+      icon: "jam jam-wrench"
+      icon_color: "purple"
+
+    - name: "Diego, startup co‑founder"
+      description: "Uses **1,000 units** for investor demos, EVT boards, and early customer trials—real silicon shortens fundraising and sales cycles."
+      icon: "jam jam-rocket"
+      icon_color: "pink"
+
+    - name: "Alex, independent developer"
+      description: "A seasoned professional going solo—uses **1,000 dies** to build eval boards and seed beta units, winning contracts without big upfront budgets."
+      icon: "jam jam-code"
+      icon_color: "yellow"
+
+highlights:
+  enable: true
+  title: "Key Points"
+  items:
+    - title: "Your chip, not just a shuttle slot"
+      description: "**20 mm²** on GF180MCU and **1,000 dies**"
+    - title: "Skip gatekeeping"
+      description: "Open PDK, open tools, clear terms"
+    - title: "Flat pricing"
+      description: "US$7k fixed price, no surprises"
+    - title: "Singapore fab, global community"
+      description: "Straightforward logistics and support"
+
+problems:
+  enable: true
+  title: "The monsters we slay"
+  items:
+    - title: "Five‑figure NRE"
+      description: "We pool designs so your share is small and fixed."
+      icon: "jam jam-coin"
+      icon_color: "red"
+    - title: "Too few parts"
+      description: "Get **1,000 included** instead of a handful."
+      icon: "jam jam-box"
+      icon_color: "blue"
+
+process_steps:
+  enable: true
+  title: "What happens after you back"
+  steps:
+    - title: "Reserve your area"
+      description: "You commit to ~20 mm² on GF180MCU."
+    - title: "Prepare your GDSII"
+      description: "Use your preferred tools—open‑source or proprietary—and the publicly documented GF180MCU PDK."
+    - title: "We panelize and tape out"
+      description: "Your design rides with peers on a shared wafer."
+    - title: "Fabricated in Singapore"
+      description: "Wafers are processed and diced."
+    - title: "Receive your parts"
+      description: "**1,000 raw dies** by default (packaging optional via third‑party OSATs)."
+
+glance:
+  enable: true
+  title: "At a glance"
+  items:
+    - label: "Process"
+      value: "GlobalFoundries **GF180MCU** (0.18 µm)"
+    - label: "What you get"
+      value: "**20 mm²** die area; **1,000 raw dies included**"
+    - label: "Price"
+      value: "**US$7,000** per slot (**US$7/part**)"
+    - label: "Packaging"
+      value: "Optional, via third parties"
+
+crowdfunding:
+  enable: true
+  title: "Why we're crowdfunding"
+  content: |
+    A pooled wafer only works when enough designs ship together. Your pledge is the signal: when we reach the threshold, we tape out. Hitting the goal locks the fab window and the **US$7/part** pricing. Crowdfunding lets us publish dates and report progress openly—exactly the transparency backers expect on Crowd Supply.
+
+about_team:
+  enable: true
+  title: "Why we'll pull it off"
+  content: |
+    wafer.space is built by people who helped open the very PDK we're using and who've shipped community silicon before. We focus on predictable **per‑part pricing** and frequent pooled runs. We're backed by a network of open‑hardware builders and advisors who care about getting *chips into more hands*, not just onto roadmaps. (See our **About** page for founder and advisor bios.)
+---
+
+{% include layouts/nav/nav.html drop_search=false alignment_class="ms-auto" %}
+{% include layouts/header/page-title.html %}
+
+<!-- Story Content -->
+{% if page.story_content.enable %}
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <div class="row">
+      <div class="col-lg-10 mx-auto">
+        {% if page.story_content.title %}
+        <h2 class="section-title mb-40 text-center">{{ page.story_content.title }}</h2>
+        {% endif %}
+        <div class="lead larger">
+          {{ page.story_content.intro | markdownify }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Personas -->
+{% if page.personas.enable %}
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    <div class="row">
+      <div class="col-md-7 mx-auto">
+        {% if page.personas.title %}
+        <h2 class="title-color color-gray text-center mb-30">{{ page.personas.title }}</h2>
+        {% endif %}
+        {% if page.personas.sub_title %}
+        <h3 class="display-3 text-center">{{ page.personas.sub_title }}</h3>
+        {% endif %}
+      </div>
+    </div>
+    <div class="space40"></div>
+    <div class="row">
+      {% for persona in page.personas.list %}
+      <div class="col-md-6 col-lg-4 mb-30">
+        <div class="box bg-white shadow p-30">
+          <div class="icon icon-blob icon-blob-{{persona.icon_color}} color-{{persona.icon_color}} mb-20">
+            <i class="{{persona.icon}}"></i>
+          </div>
+          <h5>{{ persona.name }}</h5>
+          <p>{{ persona.description | markdownify | remove: '<p>' | remove: '</p>' }}</p>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Highlights -->
+{% if page.highlights.enable %}
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <h2 class="section-title mb-40 text-center">{{ page.highlights.title }}</h2>
+    <div class="row text-center gutter-60">
+      {% for item in page.highlights.items %}
+      <div class="col-md-6 col-lg-3">
+        <h5>{{ item.title }}</h5>
+        <p>{{ item.description | markdownify | remove: '<p>' | remove: '</p>' }}</p>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Problems We Solve -->
+{% if page.problems.enable %}
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    <h2 class="section-title mb-40 text-center">{{ page.problems.title }}</h2>
+    <div class="row">
+      {% for problem in page.problems.items %}
+      <div class="col-md-6">
+        <div class="d-flex flex-row mb-30">
+          <div>
+            <span class="icon icon-blob icon-blob-{{problem.icon_color}} color-{{problem.icon_color}} mr-25">
+              <i class="{{problem.icon}}"></i>
+            </span>
+          </div>
+          <div>
+            <h5>{{ problem.title }}</h5>
+            <p>{{ problem.description | markdownify | remove: '<p>' | remove: '</p>' }}</p>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Process Steps -->
+{% if page.process_steps.enable %}
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <h2 class="section-title mb-40 text-center">{{ page.process_steps.title }}</h2>
+    <div class="row">
+      <div class="col-lg-8 mx-auto">
+        <ol class="process-list">
+          {% for step in page.process_steps.steps %}
+          <li>
+            <h5>{{ step.title }}</h5>
+            <p>{{ step.description | markdownify | remove: '<p>' | remove: '</p>' }}</p>
+          </li>
+          {% endfor %}
+        </ol>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- At a Glance -->
+{% if page.glance.enable %}
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    <h2 class="section-title mb-40 text-center">{{ page.glance.title }}</h2>
+    <div class="row">
+      <div class="col-lg-8 mx-auto">
+        <div class="box bg-white shadow p-30">
+          <ul class="unordered-list list-default">
+            {% for item in page.glance.items %}
+            <li><strong>{{ item.label }}:</strong> {{ item.value | markdownify | remove: '<p>' | remove: '</p>' }}</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- Crowdfunding -->
+{% if page.crowdfunding.enable %}
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <div class="row">
+      <div class="col-lg-8 mx-auto">
+        <h2 class="section-title mb-30">{{ page.crowdfunding.title }}</h2>
+        <div class="lead">
+          {{ page.crowdfunding.content | markdownify }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<!-- About Team -->
+{% if page.about_team.enable %}
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    <div class="row">
+      <div class="col-lg-8 mx-auto">
+        <h2 class="section-title mb-30">{{ page.about_team.title }}</h2>
+        <div class="lead">
+          {{ page.about_team.content | markdownify }}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}
+
+<div class="space120"></div>
+
+<!--/.footer Wrapper-->
+{% include layouts/footer/footer-1.html %}


### PR DESCRIPTION
## Summary
- Updated homepage with silicon manufacturing campaign content from temp/ directory
- Added new story page with complete narrative about wafer.space mission
- Integrated pricing, specifications, and FAQ sections

## Changes Made

### Homepage (index.html)
- Updated hero section with $7,000 for ~1,000 dies messaging
- Enabled and populated features section with silicon manufacturing benefits
- Updated "Who Is It For?" section with target audience personas
- Modified "How It Works" with silicon manufacturing process steps
- Updated specifications section with GF180MCU process details
- Simplified pricing table to single $7,000 standard slot option
- Added FAQ section with common questions about the service

### Story Page (story.html)
- Created new page with complete wafer.space narrative
- Added personas for different user types (students, makers, startups, etc.)
- Included key highlights and value propositions
- Listed problems being solved (high NRE, too few parts)
- Detailed process steps for backers
- Added at-a-glance specifications
- Explained crowdfunding rationale and team credibility

## Test Plan
- [x] Built site locally with `make build`
- [x] Verified site serves correctly at http://localhost:4000
- [x] Confirmed all content displays properly
- [x] Site now has 18 HTML files (added story.html)

🤖 Generated with [Claude Code](https://claude.ai/code)