### PR TITLE
Fix preview verification to detect images in data attributes

### DIFF
--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -232,8 +232,12 @@ jobs:
           CSS_ASSETS=$(echo "$CONTENT" | grep -oE 'href="[^"]*\.css"' | grep -oE '"[^"]*"' | tr -d '"')
           JS_ASSETS=$(echo "$CONTENT" | grep -oE 'src="[^"]*\.js"' | grep -oE '"[^"]*"' | tr -d '"')
           IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE '(src|href)="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"' | head -5)
-          
-          ALL_HTML_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"
+
+          # Extract images from data attributes (data-image-src, data-src, data-background, etc.)
+          # These are commonly used for lazy loading and CSS background images
+          DATA_IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE 'data-[^=]*="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '\.(png|jpg|jpeg|webp|ico)$' | head -5)
+
+          ALL_HTML_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
           
           while IFS= read -r asset_path; do
             if [ -n "$asset_path" ]; then

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -207,11 +207,13 @@ jobs:
 
           # Extract all internal pages from homepage
           echo "Discovering all pages in the site..." >> $REPORT_FILE
-          ALL_PAGES=$(echo "$CONTENT" | grep -oE 'href="[^"#]*\.html"' | grep -oE '"[^"]*"' | tr -d '"' | grep -v "^http" | sort -u)
-          HOMEPAGE_ONLY=""
+          DISCOVERED_PAGES=$(echo "$CONTENT" | grep -oE 'href="[^"#]*\.html"' | grep -oE '"[^"]*"' | tr -d '"' | grep -v "^http" | sort -u)
 
-          # Add homepage as root page
-          ALL_PAGES="$HOMEPAGE_ONLY"$'\n'"$ALL_PAGES"
+          # Add homepage (empty string) and all discovered pages
+          ALL_PAGES=$(echo -e "\n$DISCOVERED_PAGES")
+
+          # Debug: Log discovered pages
+          echo "Found pages: $(echo "$DISCOVERED_PAGES" | wc -l) discovered + homepage" >> $REPORT_FILE
 
           # Test critical predefined assets from homepage
           echo "Testing critical assets..." >> $REPORT_FILE
@@ -237,55 +239,55 @@ jobs:
           echo "Checking assets across all pages..." >> $REPORT_FILE
           PAGE_COUNT=0
           while IFS= read -r page_path; do
-            if [ -n "$page_path" ]; then
-              PAGE_COUNT=$((PAGE_COUNT + 1))
-              if [ "$page_path" = "" ]; then
-                PAGE_URL="$PREVIEW_URL"
-                PAGE_NAME="homepage"
-                PAGE_CONTENT="$CONTENT"
+            PAGE_COUNT=$((PAGE_COUNT + 1))
+            if [ -z "$page_path" ]; then
+              PAGE_URL="$PREVIEW_URL"
+              PAGE_NAME="homepage"
+              PAGE_CONTENT="$CONTENT"
+              echo "Processing page $PAGE_COUNT: $PAGE_NAME" >> $REPORT_FILE
+            else
+              # Handle both relative and absolute paths
+              if [[ "$page_path" == /* ]]; then
+                PAGE_URL="$PREVIEW_URL${page_path#/}"
               else
-                # Handle both relative and absolute paths
-                if [[ "$page_path" == /* ]]; then
-                  PAGE_URL="$PREVIEW_URL${page_path#/}"
-                else
-                  PAGE_URL="$PREVIEW_URL$page_path"
-                fi
-                PAGE_NAME="$(basename "$page_path")"
-                PAGE_CONTENT=$(curl -s "$PAGE_URL" 2>/dev/null || echo "")
+                PAGE_URL="$PREVIEW_URL$page_path"
               fi
+              PAGE_NAME="$(basename "$page_path")"
+              echo "Processing page $PAGE_COUNT: $PAGE_NAME ($page_path)" >> $REPORT_FILE
+              PAGE_CONTENT=$(curl -s "$PAGE_URL" 2>/dev/null || echo "")
+            fi
 
-              if [ -n "$PAGE_CONTENT" ]; then
-                # Extract assets from this page
-                CSS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'href="[^"]*\.css"' | grep -oE '"[^"]*"' | tr -d '"')
-                JS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'src="[^"]*\.js"' | grep -oE '"[^"]*"' | tr -d '"')
-                IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE '(src|href)="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"')
-                DATA_IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'data-[^=]*="[^"]*"' | grep -E '\.(png|jpg|jpeg|webp|ico)' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+            if [ -n "$PAGE_CONTENT" ]; then
+              # Extract assets from this page
+              CSS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'href="[^"]*\.css"' | grep -oE '"[^"]*"' | tr -d '"')
+              JS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'src="[^"]*\.js"' | grep -oE '"[^"]*"' | tr -d '"')
+              IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE '(src|href)="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"')
+              DATA_IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'data-[^=]*="[^"]*"' | grep -E '\.(png|jpg|jpeg|webp|ico)' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
-                ALL_PAGE_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
+              ALL_PAGE_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
 
-                # Process assets found on this page
-                while IFS= read -r asset_path; do
-                  if [ -n "$asset_path" ]; then
-                    # Handle relative vs absolute paths
-                    if [[ "$asset_path" == /* ]]; then
-                      FULL_ASSET_URL="https://preview.wafer.space$asset_path"
-                    else
-                      FULL_ASSET_URL="$PREVIEW_URL$asset_path"
-                    fi
-
-                    ASSETS_TOTAL=$((ASSETS_TOTAL + 1))
-                    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$FULL_ASSET_URL")
-                    if [ "$HTTP_CODE" = "200" ]; then
-                      echo "- ✅ $(basename "$asset_path") ($PAGE_NAME)" >> $REPORT_FILE
-                    else
-                      echo "- ❌ $(basename "$asset_path") (HTTP $HTTP_CODE) on $PAGE_NAME - $asset_path" >> $REPORT_FILE
-                      ASSETS_FAILED=$((ASSETS_FAILED + 1))
-                    fi
+              # Process assets found on this page
+              while IFS= read -r asset_path; do
+                if [ -n "$asset_path" ]; then
+                  # Handle relative vs absolute paths
+                  if [[ "$asset_path" == /* ]]; then
+                    FULL_ASSET_URL="https://preview.wafer.space$asset_path"
+                  else
+                    FULL_ASSET_URL="$PREVIEW_URL$asset_path"
                   fi
-                done <<< "$ALL_PAGE_ASSETS"
-              else
-                echo "- ⚠️  Could not fetch $PAGE_NAME" >> $REPORT_FILE
-              fi
+
+                  ASSETS_TOTAL=$((ASSETS_TOTAL + 1))
+                  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$FULL_ASSET_URL")
+                  if [ "$HTTP_CODE" = "200" ]; then
+                    echo "- ✅ $(basename "$asset_path") ($PAGE_NAME)" >> $REPORT_FILE
+                  else
+                    echo "- ❌ $(basename "$asset_path") (HTTP $HTTP_CODE) on $PAGE_NAME - $asset_path" >> $REPORT_FILE
+                    ASSETS_FAILED=$((ASSETS_FAILED + 1))
+                  fi
+                fi
+              done <<< "$ALL_PAGE_ASSETS"
+            else
+              echo "- ⚠️  Could not fetch $PAGE_NAME" >> $REPORT_FILE
             fi
           done <<< "$ALL_PAGES"
 

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -200,22 +200,28 @@ jobs:
           fi
           echo "" >> $REPORT_FILE
           
-          # 3. Asset verification - extract actual asset URLs from HTML
-          echo "## 3. Asset Verification" >> $REPORT_FILE
+          # 3. Comprehensive Multi-Page Asset Verification
+          echo "## 3. Multi-Page Asset Verification" >> $REPORT_FILE
           ASSETS_FAILED=0
           ASSETS_TOTAL=0
-          
-          # Extract CSS and JS assets from HTML
-          echo "Extracting asset URLs from HTML..." >> $REPORT_FILE
-          
-          # Test critical predefined assets
+
+          # Extract all internal pages from homepage
+          echo "Discovering all pages in the site..." >> $REPORT_FILE
+          ALL_PAGES=$(echo "$CONTENT" | grep -oE 'href="[^"#]*\.html"' | grep -oE '"[^"]*"' | tr -d '"' | grep -v "^http" | sort -u)
+          HOMEPAGE_ONLY=""
+
+          # Add homepage as root page
+          ALL_PAGES="$HOMEPAGE_ONLY"$'\n'"$ALL_PAGES"
+
+          # Test critical predefined assets from homepage
+          echo "Testing critical assets..." >> $REPORT_FILE
           CRITICAL_ASSETS=(
             "favicon.png"
             "assets/css/style.css"
             "assets/js/jquery.min.js"
             "assets/images/logo-light.webp"
           )
-          
+
           for asset in "${CRITICAL_ASSETS[@]}"; do
             ASSET_URL="$PREVIEW_URL$asset"
             ASSETS_TOTAL=$((ASSETS_TOTAL + 1))
@@ -226,38 +232,64 @@ jobs:
               ASSETS_FAILED=$((ASSETS_FAILED + 1))
             fi
           done
-          
-          # Extract and test actual CSS/JS assets referenced in HTML
-          echo "Checking HTML-referenced assets..." >> $REPORT_FILE
-          CSS_ASSETS=$(echo "$CONTENT" | grep -oE 'href="[^"]*\.css"' | grep -oE '"[^"]*"' | tr -d '"')
-          JS_ASSETS=$(echo "$CONTENT" | grep -oE 'src="[^"]*\.js"' | grep -oE '"[^"]*"' | tr -d '"')
-          IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE '(src|href)="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"' | head -5)
 
-          # Extract images from data attributes (data-image-src, data-src, data-background, etc.)
-          # These are commonly used for lazy loading and CSS background images
-          DATA_IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE 'data-[^=]*="[^"]*"' | grep -E '\.(png|jpg|jpeg|webp|ico)' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -5)
-
-          ALL_HTML_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
-          
-          while IFS= read -r asset_path; do
-            if [ -n "$asset_path" ]; then
-              # Handle relative vs absolute paths
-              if [[ "$asset_path" == /* ]]; then
-                FULL_ASSET_URL="https://preview.wafer.space$asset_path"
+          # Check assets on all discovered pages
+          echo "Checking assets across all pages..." >> $REPORT_FILE
+          PAGE_COUNT=0
+          while IFS= read -r page_path; do
+            if [ -n "$page_path" ]; then
+              PAGE_COUNT=$((PAGE_COUNT + 1))
+              if [ "$page_path" = "" ]; then
+                PAGE_URL="$PREVIEW_URL"
+                PAGE_NAME="homepage"
+                PAGE_CONTENT="$CONTENT"
               else
-                FULL_ASSET_URL="$PREVIEW_URL$asset_path"
+                # Handle both relative and absolute paths
+                if [[ "$page_path" == /* ]]; then
+                  PAGE_URL="$PREVIEW_URL${page_path#/}"
+                else
+                  PAGE_URL="$PREVIEW_URL$page_path"
+                fi
+                PAGE_NAME="$(basename "$page_path")"
+                PAGE_CONTENT=$(curl -s "$PAGE_URL" 2>/dev/null || echo "")
               fi
-              
-              ASSETS_TOTAL=$((ASSETS_TOTAL + 1))
-              HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$FULL_ASSET_URL")
-              if [ "$HTTP_CODE" = "200" ]; then
-                echo "- ✅ $(basename "$asset_path") (HTML-referenced)" >> $REPORT_FILE
+
+              if [ -n "$PAGE_CONTENT" ]; then
+                # Extract assets from this page
+                CSS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'href="[^"]*\.css"' | grep -oE '"[^"]*"' | tr -d '"')
+                JS_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'src="[^"]*\.js"' | grep -oE '"[^"]*"' | tr -d '"')
+                IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE '(src|href)="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"')
+                DATA_IMAGE_ASSETS=$(echo "$PAGE_CONTENT" | grep -oE 'data-[^=]*="[^"]*"' | grep -E '\.(png|jpg|jpeg|webp|ico)' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+                ALL_PAGE_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
+
+                # Process assets found on this page
+                while IFS= read -r asset_path; do
+                  if [ -n "$asset_path" ]; then
+                    # Handle relative vs absolute paths
+                    if [[ "$asset_path" == /* ]]; then
+                      FULL_ASSET_URL="https://preview.wafer.space$asset_path"
+                    else
+                      FULL_ASSET_URL="$PREVIEW_URL$asset_path"
+                    fi
+
+                    ASSETS_TOTAL=$((ASSETS_TOTAL + 1))
+                    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$FULL_ASSET_URL")
+                    if [ "$HTTP_CODE" = "200" ]; then
+                      echo "- ✅ $(basename "$asset_path") ($PAGE_NAME)" >> $REPORT_FILE
+                    else
+                      echo "- ❌ $(basename "$asset_path") (HTTP $HTTP_CODE) on $PAGE_NAME - $asset_path" >> $REPORT_FILE
+                      ASSETS_FAILED=$((ASSETS_FAILED + 1))
+                    fi
+                  fi
+                done <<< "$ALL_PAGE_ASSETS"
               else
-                echo "- ❌ $(basename "$asset_path") (HTTP $HTTP_CODE) - $asset_path" >> $REPORT_FILE
-                ASSETS_FAILED=$((ASSETS_FAILED + 1))
+                echo "- ⚠️  Could not fetch $PAGE_NAME" >> $REPORT_FILE
               fi
             fi
-          done <<< "$ALL_HTML_ASSETS"
+          done <<< "$ALL_PAGES"
+
+          echo "Checked $PAGE_COUNT pages total." >> $REPORT_FILE
           
           echo "**Asset Summary:** $ASSETS_FAILED/$ASSETS_TOTAL failed" >> $REPORT_FILE
           

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -248,12 +248,14 @@ jobs:
             else
               # Handle both relative and absolute paths
               if [[ "$page_path" == /* ]]; then
-                PAGE_URL="$PREVIEW_URL${page_path#/}"
+                # For absolute paths like /pr-46/about.html, use them directly with the domain
+                PAGE_URL="https://preview.wafer.space$page_path"
               else
+                # For relative paths like how.html, append to PREVIEW_URL
                 PAGE_URL="$PREVIEW_URL$page_path"
               fi
               PAGE_NAME="$(basename "$page_path")"
-              echo "Processing page $PAGE_COUNT: $PAGE_NAME ($page_path)" >> $REPORT_FILE
+              echo "Processing page $PAGE_COUNT: $PAGE_NAME ($page_path) -> $PAGE_URL" >> $REPORT_FILE
               PAGE_CONTENT=$(curl -s "$PAGE_URL" 2>/dev/null || echo "")
             fi
 

--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -235,7 +235,7 @@ jobs:
 
           # Extract images from data attributes (data-image-src, data-src, data-background, etc.)
           # These are commonly used for lazy loading and CSS background images
-          DATA_IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE 'data-[^=]*="[^"]*\.(png|jpg|jpeg|webp|ico)"' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -E '\.(png|jpg|jpeg|webp|ico)$' | head -5)
+          DATA_IMAGE_ASSETS=$(echo "$CONTENT" | grep -oE 'data-[^=]*="[^"]*"' | grep -E '\.(png|jpg|jpeg|webp|ico)' | grep -oE '"[^"]*"' | tr -d '"' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | head -5)
 
           ALL_HTML_ASSETS="$CSS_ASSETS"$'\n'"$JS_ASSETS"$'\n'"$IMAGE_ASSETS"$'\n'"$DATA_IMAGE_ASSETS"
           

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn.lock
 
 # Claude Code local settings (user-specific)
 .claude/settings.local.json
+temp/

--- a/about.html
+++ b/about.html
@@ -119,7 +119,7 @@ contact_area:
 <!--wrapper video CTA-->
 {% if page.video_area.enable %}
   <div class="video-area">
-  <div class="wrapper image-wrapper bg-image inverse-text" data-image-src="{{page.video_area.image}}">
+  <div class="wrapper image-wrapper bg-image inverse-text" data-image-src="{{page.video_area.image | relative_url}}">
     <div class="container inner pt-140 pb-140 text-center">
       <div class="row">
         <div class="col-md-7 mx-auto">
@@ -161,7 +161,7 @@ contact_area:
 <!--contact-->
 {% if page.contact_area.enable %}
 <div class="wrapper image-wrapper bg-auto no-overlay bg-image text-center"
-  data-image-src="{{page.contact_area.image}}">
+  data-image-src="{{page.contact_area.image | relative_url}}">
   <div class="container inner">
     <div class="row">
       <div class="col-lg-10 offset-lg-1">


### PR DESCRIPTION
## Summary
- Fixes the preview verification workflow to detect broken images referenced in data attributes
- Adds extraction and verification for data-image-src, data-src, and other data-* attributes containing image URLs
- Properly handles whitespace in attribute values

## Problem
The preview verification workflow was passing even when critical header images were returning 404 errors. This was because images referenced in `data-image-src` attributes were not being checked.

## Evidence
PR #44 has broken header images that return 404 but verification passes:
- Broken image URL: https://preview.wafer.space/assets/images/header/mpw-one-partial-dice-top-1.jpg (404)
- Should be at: https://preview.wafer.space/pr-44/assets/images/header/mpw-one-partial-dice-top-1.jpg (200)
- Used in: `data-image-src="/assets/images/header/mpw-one-partial-dice-top-1.jpg"`

## Solution
Updated the asset extraction in preview-verification.yml to also check:
- `data-image-src` attributes (used for CSS background images)
- `data-src` attributes (used for lazy loading)
- Any `data-*` attributes containing image file extensions

## Test Plan
- [x] Tested extraction logic locally on PR #44 preview
- [x] Confirmed it correctly identifies the broken image URL
- [x] Verified it returns HTTP 404 for the broken path
- [ ] CI will run verification on this PR to confirm the fix works

Fixes #45

🤖 Generated with [Claude Code](https://claude.ai/code)