### PR TITLE
Add .worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ yarn.lock
 # Claude Code local settings (user-specific)
 .claude/settings.local.json
 temp/
+.worktrees/


### PR DESCRIPTION
## Summary
- Adds `.worktrees/` to `.gitignore` to prevent git worktree directories from being tracked

Cherry-picked from the now-merged `bailey-cvc` branch (commit 63bb66e) where this was the only unmerged change.

## Test plan
- Verify `.worktrees/` directory no longer appears in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git repository configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->