### PR TITLE
Add run status page with timeline visualization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,10 @@ test: build
 	@echo "Running basic tests..."
 	@echo -n "Checking HTML file count: "
 	@HTML_COUNT=$$(find $(SITE_DIR) -name "*.html" | wc -l); \
-	if [ $$HTML_COUNT -eq 17 ]; then \
-		echo "✅ $$HTML_COUNT HTML files (expected: 17)"; \
+	if [ $$HTML_COUNT -eq 31 ]; then \
+		echo "✅ $$HTML_COUNT HTML files (expected: 31)"; \
 	else \
-		echo "❌ $$HTML_COUNT HTML files (expected: 17)"; \
+		echo "❌ $$HTML_COUNT HTML files (expected: 31)"; \
 		exit 1; \
 	fi
 	@echo -n "Checking theme plugin: "

--- a/_data/general_settings.yml
+++ b/_data/general_settings.yml
@@ -72,6 +72,8 @@ external_links:
       text: "News"
     - url: "/how.html"
       text: "How"
+    - url: "/status.html"
+      text: "Status"
     - url: "/help.html"
       text: "Help"
     - url: "/faq.html"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -16,6 +16,10 @@ main_menu:
     url: "/how.html"
     menu_type: "simple"
 
+  - text: "Status"
+    url: "/status.html"
+    menu_type: "simple"
+
   - text: "Help"
     url: "/help.html"
     menu_type: "simple"

--- a/_data/runs.yml
+++ b/_data/runs.yml
@@ -49,45 +49,85 @@ runs:
       priority: "info"
 
     # Complete timeline for manufacturing process
+    # completed: true/false tracks whether each milestone has actually occurred
     timeline:
       - title: "Purchase Deadline"
         date: "2025-11-28"
         display_date: "28 November 2025 @ 11:59 PM AoE"
         description: "Final deadline to purchase manufacturing slots"
         status: "critical"
+        completed: true
       - title: "Design Submission"
         date: "2025-12-03"
         display_date: "3 December 2025 @ 11:59 PM AoE"
         description: "Final deadline to submit GDS files for fabrication"
         status: "critical"
+        completed: true
       - title: "Tape-out to GlobalFoundries"
         date: "2025-12-05"
         display_date: "5 December 2025"
         description: "GDS files delivered to GlobalFoundries for fabrication"
         status: "milestone"
+        completed: true
       - title: "Fabrication Complete"
         date: "2026-02-15"
         display_date: "February 2026"
         description: "Wafers returned from GlobalFoundries fabrication"
         status: "milestone"
+        completed: true
       - title: "Delivery to Customers"
         date: "2026-03-15"
         display_date: "15 March 2026"
         description: "Finished dies shipped to customers worldwide"
         status: "delivery"
+        completed: false
 
-  # Future run example (commented out for now)
-  # gf180mcu_run_2:
-  #   name: "GF180MCU Run 2"
-  #   process: "GF180MCU"
-  #   run_number: 2
-  #   status: "upcoming"
-  #   featured: false
-  #   campaign_deadline:
-  #     date: "2026-06-15"
-  #     display_date: "15 June 2026"
-  #     title: "Next Campaign Opening"
-  #     subtitle: "GF180MCU Run 2 slots will be available soon"
-  #     button_text: "Get Notified"
-  #     button_url: "/subscribe.html"
-  #     priority: "info"
+  gf180mcu_run_2:
+    name: "GF180MCU Run 2"
+    process: "GF180MCU"
+    run_number: 2
+    status: "upcoming"
+    featured: false
+
+    campaign_deadline:
+      date: "2026-06-30T11:59:00Z"
+      display_date: "30 June 2026 @ 11:59 PM"
+      timezone: "AoE"
+      timezone_link: "https://en.wikipedia.org/wiki/Anywhere_on_Earth"
+      title: "Campaign Deadline"
+      subtitle: "Reserve your slot in GF180MCU Run 2"
+      button_text: "Get Notified"
+      button_url: "https://buy.wafer.space/#products"
+      priority: "info"
+
+    timeline:
+      - title: "Campaign Opens"
+        date: "2026-05-01"
+        display_date: "1 May 2026"
+        description: "Slot purchases open for GF180MCU Run 2"
+        status: "milestone"
+        completed: false
+      - title: "Purchase Deadline"
+        date: "2026-06-30"
+        display_date: "30 June 2026 @ 11:59 PM AoE"
+        description: "Final deadline to purchase manufacturing slots"
+        status: "critical"
+        completed: false
+      - title: "Design Submission"
+        date: "2026-07-15"
+        display_date: "15 July 2026"
+        description: "Final deadline to submit GDS files"
+        status: "critical"
+        completed: false
+      - title: "Tape-out to GlobalFoundries"
+        date: "2026-07-20"
+        display_date: "20 July 2026"
+        description: "GDS files delivered to GlobalFoundries"
+        status: "milestone"
+        completed: false
+      - title: "Delivery to Customers"
+        date: "2026-12-15"
+        display_date: "15 December 2026"
+        description: "Finished dies shipped to customers"
+        status: "delivery"
+        completed: false

--- a/_includes/components/run-status-card.html
+++ b/_includes/components/run-status-card.html
@@ -1,0 +1,129 @@
+{% comment %}
+  Run Status Card Component
+  Displays a single run's timeline with rocket progress marker.
+
+  Usage: {% include components/run-status-card.html run=run %}
+  Expects: run object with .name, .process, .status, .timeline[] (each with .completed)
+{% endcomment %}
+
+{% comment %} --- Compute progress --- {% endcomment %}
+{% assign total = include.run.timeline | size %}
+{% assign completed_count = 0 %}
+{% assign current_index = -1 %}
+{% for milestone in include.run.timeline %}
+  {% if milestone.completed == true %}
+    {% assign completed_count = completed_count | plus: 1 %}
+  {% elsif current_index == -1 %}
+    {% assign current_index = forloop.index0 %}
+  {% endif %}
+{% endfor %}
+
+{% comment %} Progress percentage: position at the last completed milestone {% endcomment %}
+{% assign segments = total | minus: 1 %}
+{% if segments > 0 %}
+  {% if completed_count == 0 %}
+    {% assign progress_pct = 0 %}
+    {% assign rocket_pct = 0 %}
+  {% elsif completed_count >= total %}
+    {% assign progress_pct = 100 %}
+    {% assign rocket_pct = 100 %}
+  {% else %}
+    {% assign progress_pct = completed_count | minus: 1 | times: 100 | divided_by: segments %}
+    {% assign rocket_pct = completed_count | times: 100 | divided_by: segments %}
+    {% comment %} Place rocket halfway between last completed and next milestone {% endcomment %}
+    {% assign half_segment = 50 | divided_by: segments %}
+    {% assign rocket_pct = progress_pct | plus: half_segment %}
+  {% endif %}
+{% else %}
+  {% assign progress_pct = 0 %}
+  {% assign rocket_pct = 0 %}
+{% endif %}
+
+<div class="run-card" data-status="{{ include.run.status }}">
+  <div class="box bg-white shadow p-4 mb-40">
+
+    <!-- Card header -->
+    <div class="d-flex justify-content-between align-items-center mb-30">
+      <div>
+        <h4 class="mb-0">{{ include.run.name }}</h4>
+        <span class="text-muted">{{ include.run.process }} &middot; Run {{ include.run.run_number }}</span>
+      </div>
+      <span class="run-status-badge run-status-badge-{{ include.run.status }}">
+        {{ include.run.status | capitalize }}
+      </span>
+    </div>
+
+    <!-- Timeline visualization -->
+    <div class="run-status-timeline">
+      <!-- Track with progress fill -->
+      <div class="run-status-track">
+        <div class="run-status-progress" style="width: {{ progress_pct }}%;"></div>
+        <!-- Rocket marker -->
+        {% if completed_count < total %}
+        <img src="{{ '/assets/images/art/rocket2.webp' | relative_url }}"
+             alt="Current progress"
+             class="run-status-rocket"
+             style="left: {{ rocket_pct }}%;">
+        {% else %}
+        <img src="{{ '/assets/images/art/rocket2.webp' | relative_url }}"
+             alt="Run completed"
+             class="run-status-rocket"
+             style="left: 100%;">
+        {% endif %}
+      </div>
+
+      <!-- Milestone markers -->
+      <div class="run-status-milestones">
+        {% for milestone in include.run.timeline %}
+          {% comment %} Determine dot state {% endcomment %}
+          {% if milestone.completed == true %}
+            {% assign dot_class = "completed" %}
+          {% elsif forloop.index0 == current_index %}
+            {% assign dot_class = "current" %}
+          {% else %}
+            {% assign dot_class = "future" %}
+          {% endif %}
+
+          <div class="run-status-milestone">
+            <div class="run-status-dot {{ dot_class }}"></div>
+            <div class="run-status-milestone-text">
+              <div class="run-status-label">{{ milestone.title }}</div>
+              <div class="run-status-date">{{ milestone.display_date }}</div>
+            </div>
+          </div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <!-- Milestone details table -->
+    <div class="table-responsive mt-30">
+      <table class="table table-hover table-borderless">
+        <thead>
+          <tr class="text-center">
+            <th scope="col" class="font-weight-bold">Milestone</th>
+            <th scope="col" class="font-weight-bold">Date</th>
+            <th scope="col" class="font-weight-bold">Description</th>
+            <th scope="col" class="font-weight-bold">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for milestone in include.run.timeline %}
+            <tr class="text-center timeline-row timeline-{{ milestone.status }}">
+              <td class="font-weight-600">{{ milestone.title }}</td>
+              <td class="text-muted">{{ milestone.display_date }}</td>
+              <td class="text-muted">{{ milestone.description }}</td>
+              <td>
+                {% if milestone.completed == true %}
+                  <span class="run-status-actual">Completed</span>
+                {% else %}
+                  <span class="run-status-projected">Projected</span>
+                {% endif %}
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+
+  </div>
+</div>

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -73,3 +73,248 @@
 .box.bg-white.shadow.mb-30[id] {
     scroll-margin-top: 100px;
 }
+
+/* ==========================================================================
+   Run Status Page
+   ========================================================================== */
+
+/* --- Filter tabs --- */
+.run-status-filters .nav-link {
+    cursor: pointer;
+    font-weight: 600;
+    color: #6c757d;
+    border: none;
+    padding: 0.6rem 1.2rem;
+    border-radius: 0.4rem;
+    transition: all 0.2s ease;
+}
+
+.run-status-filters .nav-link:hover {
+    color: var(--color-default);
+    background-color: rgba(95, 134, 190, 0.08);
+}
+
+.run-status-filters .nav-link.active {
+    color: #fff;
+    background-color: var(--color-default);
+}
+
+/* --- Status badges --- */
+.run-status-badge {
+    display: inline-block;
+    padding: 0.3em 0.8em;
+    border-radius: 2rem;
+    font-size: 0.8rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.run-status-badge-active {
+    background-color: rgba(95, 134, 190, 0.15);
+    color: var(--color-default);
+}
+
+.run-status-badge-upcoming {
+    background-color: rgba(108, 117, 125, 0.12);
+    color: #6c757d;
+}
+
+.run-status-badge-completed {
+    background-color: rgba(40, 167, 69, 0.12);
+    color: #28a745;
+}
+
+/* --- Timeline container --- */
+.run-status-timeline {
+    position: relative;
+    padding: 40px 25px 20px;
+}
+
+/* --- Track (background bar) --- */
+.run-status-track {
+    position: relative;
+    height: 6px;
+    background: rgba(0, 0, 0, 0.08);
+    border-radius: 3px;
+    margin-bottom: 0;
+}
+
+/* --- Progress fill --- */
+.run-status-progress {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    background: linear-gradient(90deg, #28a745, #34ce57);
+    border-radius: 3px;
+    transition: width 0.6s ease;
+}
+
+/* --- Rocket marker --- */
+.run-status-rocket {
+    position: absolute;
+    top: 50%;
+    z-index: 10;
+    width: 48px;
+    height: auto;
+    transform: translate(-50%, -50%) rotate(90deg);
+    filter: drop-shadow(0 2px 6px rgba(0, 0, 0, 0.25));
+    transition: left 0.6s ease;
+}
+
+/* --- Milestone markers row --- */
+.run-status-milestones {
+    display: flex;
+    justify-content: space-between;
+    position: relative;
+    margin-top: -3px;
+    padding-top: 0;
+}
+
+/* --- Individual milestone --- */
+.run-status-milestone {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    flex: 0 0 auto;
+    max-width: 120px;
+}
+
+/* Position first and last milestones at edges */
+.run-status-milestone:first-child {
+    align-items: flex-start;
+    text-align: left;
+}
+
+.run-status-milestone:last-child {
+    align-items: flex-end;
+    text-align: right;
+}
+
+/* --- Milestone dot --- */
+.run-status-dot {
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    border: 3px solid #ced4da;
+    background: #fff;
+    position: relative;
+    z-index: 5;
+    flex-shrink: 0;
+}
+
+.run-status-dot.completed {
+    background: #28a745;
+    border-color: #28a745;
+}
+
+.run-status-dot.current {
+    background: var(--color-default);
+    border-color: var(--color-default);
+    animation: run-status-pulse 2s ease-in-out infinite;
+}
+
+.run-status-dot.future {
+    background: #fff;
+    border-color: #ced4da;
+    border-style: dashed;
+}
+
+/* --- Milestone labels --- */
+.run-status-label {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: #343a40;
+    margin-top: 8px;
+    line-height: 1.2;
+}
+
+.run-status-date {
+    font-size: 0.72rem;
+    color: #6c757d;
+    margin-top: 2px;
+}
+
+/* --- Milestone status text in table --- */
+.run-status-actual {
+    color: #28a745;
+    font-weight: 600;
+}
+
+.run-status-projected {
+    color: #e67e22;
+    font-weight: 600;
+}
+
+/* --- Pulse animation --- */
+@keyframes run-status-pulse {
+    0%, 100% {
+        box-shadow: 0 0 0 0 rgba(95, 134, 190, 0.5);
+    }
+    50% {
+        box-shadow: 0 0 0 10px rgba(95, 134, 190, 0);
+    }
+}
+
+/* --- Responsive: vertical timeline on mobile --- */
+@media (max-width: 767px) {
+    .run-status-timeline {
+        padding: 20px 10px;
+    }
+
+    .run-status-track {
+        width: 6px;
+        height: auto;
+        min-height: 300px;
+        position: absolute;
+        left: 30px;
+        top: 20px;
+        bottom: 20px;
+    }
+
+    .run-status-progress {
+        width: 100% !important;
+        height: var(--progress-pct);
+        left: 0;
+        top: 0;
+    }
+
+    .run-status-rocket {
+        top: auto;
+        left: 30px !important;
+        transform: translate(-50%, -50%) rotate(180deg);
+    }
+
+    .run-status-milestones {
+        flex-direction: column;
+        margin-top: 0;
+        padding-left: 60px;
+        gap: 30px;
+    }
+
+    .run-status-milestone {
+        flex-direction: row;
+        align-items: center;
+        text-align: left;
+        max-width: none;
+        gap: 12px;
+    }
+
+    .run-status-milestone:first-child,
+    .run-status-milestone:last-child {
+        align-items: center;
+        text-align: left;
+    }
+
+    .run-status-dot {
+        position: absolute;
+        left: 30px;
+        transform: translateX(-50%);
+    }
+
+    .run-status-milestone-text {
+        padding-left: 0;
+    }
+}

--- a/status.html
+++ b/status.html
@@ -1,0 +1,108 @@
+---
+layout: default
+title: "Run Status"
+sub_title: |
+  Track the progress of wafer.space manufacturing runs from tape-out to delivery.
+header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
+---
+{% include layouts/nav/nav.html drop_search=false alignment_class="ms-auto" %}
+{% include layouts/header/page-title.html %}
+
+<!-- Filter tabs -->
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <h2 class="section-title mb-40 text-center">Manufacturing Run Status</h2>
+    <p class="lead larger text-center mb-40">Follow each run's journey from campaign to delivery.</p>
+
+    <div class="d-flex justify-content-center mb-40">
+      <ul class="nav run-status-filters">
+        <li class="nav-item">
+          <a class="nav-link active" data-filter="all">All</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" data-filter="active">Current</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" data-filter="upcoming">Future</a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" data-filter="completed">Completed</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+</div>
+
+<!-- Run cards -->
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    {% assign runs_data = site.data.runs.runs %}
+    {% for run_entry in runs_data %}
+      {% assign run = run_entry[1] %}
+      {% include components/run-status-card.html run=run %}
+    {% endfor %}
+
+    <!-- Empty state for filtered views -->
+    <div class="run-card-empty text-center py-5" style="display: none;">
+      <h4 class="text-muted">No runs match this filter.</h4>
+    </div>
+  </div>
+</div>
+
+<div class="space120"></div>
+
+{% include layouts/footer/footer-1.html %}
+
+<!-- Filtering and URL hash support -->
+<script>
+(function() {
+  'use strict';
+
+  function applyFilter(filter) {
+    var $cards = $('.run-card');
+    var $empty = $('.run-card-empty');
+    var visibleCount = 0;
+
+    if (filter === 'all') {
+      $cards.show();
+      visibleCount = $cards.length;
+    } else {
+      $cards.each(function() {
+        if ($(this).data('status') === filter) {
+          $(this).show();
+          visibleCount++;
+        } else {
+          $(this).hide();
+        }
+      });
+    }
+
+    // Show empty state if no matches
+    if (visibleCount === 0) {
+      $empty.show();
+    } else {
+      $empty.hide();
+    }
+
+    // Update active tab
+    $('.run-status-filters .nav-link').removeClass('active');
+    $('.run-status-filters .nav-link[data-filter="' + filter + '"]').addClass('active');
+  }
+
+  $(document).ready(function() {
+    // Tab click handler
+    $('.run-status-filters .nav-link').on('click', function(e) {
+      e.preventDefault();
+      var filter = $(this).data('filter');
+      applyFilter(filter);
+      history.replaceState(null, '', '#' + filter);
+    });
+
+    // Read initial filter from URL hash
+    var hash = window.location.hash.replace('#', '');
+    if (hash && ['all', 'active', 'upcoming', 'completed'].indexOf(hash) !== -1) {
+      applyFilter(hash);
+    }
+  });
+})();
+</script>


### PR DESCRIPTION
## Summary
- Adds a new `/status.html` page showing manufacturing run progress with horizontal timelines
- Each run displays color-coded milestones (completed/current/future) with the rocket2.webp image marking the current position
- Filter tabs (All/Current/Future/Completed) with URL hash support for direct linking
- Extends `_data/runs.yml` with `completed` field per timeline milestone and uncomments Run 2 as an upcoming run
- Adds "Status" to navigation menu and footer links
- Updates Makefile test count from stale 17 to actual 31

## Test plan
- [ ] `make test` passes with 31 HTML files
- [ ] Status page renders at `/status.html` with correct timeline visualization
- [ ] Run 1 shows 4 completed milestones + 1 current (Delivery) with rocket at ~87%
- [ ] Run 2 shows all milestones as future/current with rocket at 0%
- [ ] Filter tabs correctly show/hide runs by status
- [ ] URL hash filtering works (`/status.html#active`, `#upcoming`)
- [ ] Milestone dots pulse on current stage (sky-blue glow animation)
- [ ] Mobile responsive: timeline switches to vertical layout below 768px
- [ ] Existing countdown component still works correctly
- [ ] Navigation shows "Status" between "How" and "Help"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added "Status" page displaying manufacturing run progress with interactive filtering (all, active, upcoming, completed statuses)
* New "Status" link in main navigation and footer
* Displays milestone progress with visual timeline and completion status indicators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->