### PR TITLE
Adding new redirects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ yarn.lock
 
 # Claude Code local settings (user-specific)
 .claude/settings.local.json
+.playwright-mcp/
 temp/
 .worktrees/

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ yarn.lock
 .claude/settings.local.json
 .playwright-mcp/
 temp/
+tmp/
 .worktrees/

--- a/redirects/hw26.md
+++ b/redirects/hw26.md
@@ -1,0 +1,5 @@
+---
+permalink:  /hw26/index.html
+redirect:   https://docs.google.com/presentation/d/e/2PACX-1vTxg2AKWBO8AtXJ8W0ZIVHcHbcL_nsOZp-Yu2oOwilfjrGG2jNafn_SvngVmGArcDI0NQQNj9Yxr8IZ/pub?start=false&loop=false&delayms=3000
+layout:     redirect
+---

--- a/redirects/racquet26.md
+++ b/redirects/racquet26.md
@@ -1,0 +1,5 @@
+---
+permalink:  /racquet26/index.html
+redirect:   https://docs.google.com/presentation/d/1oHlVgYfc4DIex-FJgZ7V_o6JmpdAFVFnXjwY9eIfhAE/edit?slide=id.gc6f73a04f_0_0#slide=id.gc6f73a04f_0_0
+layout:     redirect
+---


### PR DESCRIPTION
 * https://wafer.space/hw26 --> My Hackware 2026 talk in Singapore.
 * https://wafer.space/racquet26 --> Greg Davill's talk about Racquet from Down Underflow 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added two new redirect paths providing quick access to shared learning resources

* **Chores**
  * Updated build configuration files and theme dependencies to latest versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->