### PR TITLE
Add auc26 redirect

### DIFF
--- a/redirects/auc26.md
+++ b/redirects/auc26.md
@@ -1,0 +1,5 @@
+---
+permalink:  /auc26/index.html
+redirect:   https://docs.google.com/presentation/d/e/2PACX-1vT01LbUFhJ4z637gCMlcujCXkiJ0YgOBS_I4cfeSnpiu5y9B_g2XS0MvlmHd6CTxiVI5XqAFCUm79Du/pub?start=false&loop=false&delayms=3000
+layout:     redirect
+---


### PR DESCRIPTION
## Summary
- Adds a new redirect at `/auc26/` pointing to Google Slides presentation

## Test plan
- [ ] Verify the redirect page is generated in the build output
- [ ] Confirm `/auc26/` redirects to the correct Google Slides URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new redirect at `/auc26/` providing direct access to a Google Slides presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->