### PR TITLE
Build previews using `--future` flag

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Build Jekyll site
         run: |
           # Build site with PR-specific baseurl
-          bundle exec jekyll build --baseurl "${{ steps.pr-directory.outputs.baseurl_path }}"
+          bundle exec jekyll build --baseurl "${{ steps.pr-directory.outputs.baseurl_path }}" --future
         env:
           JEKYLL_ENV: production
           


### PR DESCRIPTION
This flag will allow for future dated posts to be built by the preview workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PR preview workflow to include scheduled content during site generation. Preview deployments now display future-dated content alongside current content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wafer-space/wafer-space.github.io/pull/90?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->