### PR TITLE
Add "Community & Resources" section to website

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -28,3 +28,6 @@ main_menu:
     url: "/faq.html"
     menu_type: "simple"
 
+  - text: Community & Resources
+    url: "/community-resources"
+    menu_type: "simple"

--- a/community-resources/index.md
+++ b/community-resources/index.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: "Community & Resources"
+sub_title: Join our community, or check out some resources to help you with your next tapeout
+header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
+---
+<!-- {% include layouts/nav/nav.html drop_search=false alignment_class="ms-auto" %} -->
+{% include layouts/header/page-title.html %}
+
+<div class="wrapper light-wrapper">
+  <div class="container inner">
+    <h3 class="section-title text-center mb-20">Community</h3>
+    <p class="text-center mb-40">Discussion forums for design questions and peer support.</p>
+    <div class="row text-center">
+      <div class="col-md-6">
+        <div class="box bg-white shadow p-30">
+          <div class="icon mb-20">
+            <i class="jam jam-messages-alt" style="font-size: 48px; color: #4f66d0;"></i>
+          </div>
+          <h4>Discord</h4>
+          <p class="mb-0">Join us on discord at <a href="/discord">wafer.space/discord</a></p>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="box bg-white shadow p-30">
+          <div class="icon mb-20">
+            <i class="jam jam-messages-alt" style="font-size: 48px; color: #4f66d0;"></i>
+          </div>
+          <h4>Matrix</h4>
+          <p class="mb-0">We're also on Matrix at <a href="https://matrix.to/#/#gf180mcu:fossi-chat.org">#gf180mcu:fossi-chat.org</a></p>
+        </div>
+      </div>
+  </div>
+</div>
+
+<div class="wrapper gray-wrapper">
+  <div class="container inner">
+    <h3 class="section-title text-center mb-20">Resources</h3>
+    <p class="text-center mb-40">Documentation and previously submitted designs.</p>
+    <div class="row align-items-center">
+      <ul class="icon-list bullet-default">
+            <li>
+              <i class="jam jam-cog"></i>
+              <a href="https://github.com/wafer-space/gf180mcu-project-template" target="_blank" rel="noopener">
+                Project template
+              </a>
+              &mdash; start your design from a working example
+            </li>
+            <li>
+              <i class="jam jam-document"></i>
+              <a href="https://gf180mcu-pdk.readthedocs.io/" target="_blank" rel="noopener">
+                PDK documentation
+              </a>
+              &mdash; GF180MCU process design kit reference
+            </li>
+            <li>
+              <i class="jam jam-microchip"></i>
+              <a href="https://mithro.github.io/gf180mcu-project-template/" target="_blank" rel="noopener">
+                Slot specifications
+              </a>
+              &mdash; die dimensions, pad rings, and I/O details
+            </li>
+            <li>
+              <i class="jam jam-archive"></i>
+              <a href="https://github.com/wafer-space/ws-run1" target="_blank" rel="noopener">
+                Run 1 repository
+              </a>
+              &mdash; list of publicly accessible projects with source code
+            </li>
+          </ul>
+        </div>
+  </div>
+</div>
+
+{% include layouts/footer/footer-1.html %}

--- a/design-help.html
+++ b/design-help.html
@@ -38,7 +38,7 @@ header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
             <i class="jam jam-messages-alt" style="font-size: 48px; color: #4f66d0;"></i>
           </div>
           <h4>Community Forums</h4>
-          <p class="mb-0">Coming soon - Discussion forums for design questions and peer support.</p>
+          <p class="mb-0">Discussion forums for design questions and peer support.</p>
         </div>
       </div>
       <div class="col-md-4">
@@ -47,7 +47,7 @@ header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
             <i class="jam jam-document" style="font-size: 48px; color: #4f66d0;"></i>
           </div>
           <h4>Documentation</h4>
-          <p class="mb-0">Coming soon - Tutorials, guides, and technical documentation for GF180MCU.</p>
+          <p class="mb-0">Tutorials, guides, and technical documentation for GF180MCU.</p>
         </div>
       </div>
       <div class="col-md-4">
@@ -56,10 +56,21 @@ header_image: "/assets/images/header/mpw-one-partial-dice-top-1.jpg"
             <i class="jam jam-github" style="font-size: 48px; color: #4f66d0;"></i>
           </div>
           <h4>Open Source Tools</h4>
-          <p class="mb-0">Coming soon - Links to open-source tools and example designs for GF180MCU.</p>
+          <p class="mb-0">Links to open-source tools and example designs for GF180MCU.</p>
         </div>
       </div>
     </div>
+
+    <div class="space40"></div>
+
+    <div class="row">
+      <div class="col text-center">
+        <a href="/community-resources" class="btn btn-lg btn-default" role="button">
+          <i class="jam jam-arrow-right mr-10"></i>Go to Community & Resources
+        </a>
+      </div>
+    </div>
+
   </div>
 </div>
 


### PR DESCRIPTION
This PR adds a "Community & Resources" section to the website in order to consolidate community links and useful resources for people looking to get started with wafer.space. This page is accessible via the navbar.

Unlike the other pages, this exists within its own folder and uses `index.md` - this ensures that when built, it won't have the ugly `.html` suffix in the URL. This page should resolve to `https://wafer.space/community-resources` and not `https://wafer.space/community-resources.html`.

The design help page was also updated and now links directly to the community & resources page.

Linked resources:
- [Project template](https://github.com/wafer-space/gf180mcu-project-template)
- [GF180 PDK documentation](https://gf180mcu-pdk.readthedocs.io/)
- [Slot specifications](https://mithro.github.io/gf180mcu-project-template/)
- [Run 1 repo](https://github.com/wafer-space/ws-run1)

Closes #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Community & Resources" navigation menu item and dedicated landing page
  * Created Community section featuring Discord and Matrix community links
  * Created Resources section with four curated external resources (project template, documentation, specifications, and repository)
  * Updated Community Resources section descriptions with actual content replacing placeholders

<!-- end of auto-generated comment: release notes by coderabbit.ai -->