### PR TITLE
Fix baseurl-breaking internal link in chip-on-board-progress post

### DIFF
--- a/_posts/2026-06-03-chip-on-board-progress.md
+++ b/_posts/2026-06-03-chip-on-board-progress.md
@@ -52,7 +52,7 @@ Run 1 bare dies and chips-on-board (COBs) have shipped - join us to have a look 
 
 ## The Chip-on-Board Boards
 
-If you've been following along, you may remember a [previous update](/news/chip-on-board-strategy)
+If you've been following along, you may remember a [previous update](https://wafer.space/news/chip-on-board-strategy)
 where we discussed different potential strategies for chip-on-board packaging. In this update we will see all that hard
 work come to fruition, as we wirebond some of the very first dies from this run.
 


### PR DESCRIPTION
## Summary

Fixes a broken internal link in the "Chip-on-Board Progress" news post (`_posts/2026-06-03-chip-on-board-progress.md`).

The "previous update" link used a **root-relative** path:

```diff
-...a [previous update](/news/chip-on-board-strategy)
+...a [previous update](https://wafer.space/news/chip-on-board-strategy)
```

## Why it was broken

The site config sets `baseurl: ""`, so `/news/chip-on-board-strategy` works on production — but the **per-PR preview** is served under a non-empty baseurl (`/pr-NN/`). A root-relative path ignores baseurl, so on the preview it resolved to `preview.wafer.space/news/chip-on-board-strategy` (missing the `/pr-NN` prefix) and returned **HTTP 404**. This is what muffet flagged in the preview-verification job.

## Fix

Use the absolute `https://wafer.space/news/chip-on-board-strategy` form, which is **the convention every other internal cross-link in `_posts/` already uses** (the homepage and all `design-help.html` links are written this way). It resolves correctly regardless of baseurl. Verified the target returns **HTTP 200**.

## Test plan

- [x] Target URL returns HTTP 200 (`curl` with browser UA)
- [x] Matches existing absolute-link convention in `_posts/`
- [ ] `verify-preview` no longer reports the `news/chip-on-board-strategy` 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)
