### PR TITLE
Add rule requiring confirmation before adding muffet exclusions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,3 +129,17 @@ Make sure you are on the right branch before doing any work.
 - Once the pull request has been created, wait for the GitHub Action checks to run and fix any issues they find.
 - Wait for GitHub Copilot to review your pull request and then use the GitHub GraphQL API to find all code suggestions, fix the issues and then resolve the threads.
 
+## Preview Verification
+
+Pull requests are checked by the `preview-verification.yml` workflow, which runs the [muffet](https://github.com/raviqqe/muffet) link checker against the per-PR preview site.
+
+### NEVER Add Muffet Exclusions Without Confirmation
+
+**NEVER add exclusions to `.github/workflows/preview-verification.yml` without first asking the user for confirmation using the AskUserQuestion tool.** Exclusions hide potential problems and should be deliberate decisions, not automatic fixes.
+
+Before proposing an exclusion, you MUST:
+1. Investigate the root cause of the failure
+2. Attempt to fix the actual problem (broken URL, missing anchor, etc.)
+3. If an exclusion is truly needed, use AskUserQuestion to explain the situation and get explicit approval
+4. Document why the exclusion is necessary in the commit message
+


### PR DESCRIPTION
## Summary

Adds a documented policy to `CLAUDE.md`: **never add a muffet exclusion without first confirming via AskUserQuestion.** Exclusions hide real problems, so the agent must investigate the root cause and attempt a real fix (broken URL, missing anchor) before proposing one.

Placed under a new **"Preview Verification"** section, since current `main`'s `CLAUDE.md` has no verification section (the original PR #73 context section no longer exists).

## Provenance

Brings forward the policy from the closed **PR #73** (commit `f4b8312`, "Add rule requiring confirmation before adding muffet exclusions").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
