### PR TITLE
Fix GitHub README anchor in openfasoc-sensor post

### DIFF
--- a/_posts/2025-11-05-openfasoc-sensor.md
+++ b/_posts/2025-11-05-openfasoc-sensor.md
@@ -43,7 +43,7 @@ What's exciting is they used the exact same open-source toolchain you have acces
 - [KLayout](https://www.klayout.de/) and [Magic](https://github.com/RTimothyEdwards/magic) for layout
 - Standard DRC/LVS checks
 
-They've published their designs on GitHub in the [OpenFASoC-Tapeouts repository](https://github.com/idea-fasoc/openfasoc-tapeouts?tab=readme-ov-file#analog-front-end-and-mixed-signal), and the [final submission is available on foss-eda-tools](https://foss-eda-tools.googlesource.com/third_party/shuttle/gf180mcu/mpw-18h1/slot-004/+/refs/heads/main), which means you can actually look at exactly how they did it.
+They've published their designs on GitHub in the [OpenFASoC-Tapeouts repository](https://github.com/idea-fasoc/openfasoc-tapeouts?tab=readme-ov-file#user-content-analog-front-end-and-mixed-signal), and the [final submission is available on foss-eda-tools](https://foss-eda-tools.googlesource.com/third_party/shuttle/gf180mcu/mpw-18h1/slot-004/+/refs/heads/main), which means you can actually look at exactly how they did it.
 
 {% include image.html file="/assets/images/news/openfasoc-sensor/analog_flow.png" description="The complete open-source analog design flow used for this project" %}
 


### PR DESCRIPTION
## Summary

Fixes a broken GitHub README anchor in `_posts/2025-11-05-openfasoc-sensor.md`:

```diff
-...openfasoc-tapeouts?tab=readme-ov-file#analog-front-end-and-mixed-signal
+...openfasoc-tapeouts?tab=readme-ov-file#user-content-analog-front-end-and-mixed-signal
```

GitHub prefixes rendered README heading ids with `user-content-`, so the bare fragment had no matching id and muffet flagged it as broken.

## Verification

Confirmed GitHub's rendered README emits `id="user-content-analog-front-end-and-mixed-signal"` (and **no** un-prefixed form), so the prefixed fragment is the correct, muffet-passing target.

## Provenance

Brings forward the link fix from the closed **PR #73** (commit `4528556`). The file was renamed since then (`-sensors` → `-sensor`); the fix is applied to the current filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
