### PR TITLE
CI: add muffet --rate-limit to reduce transient external 504 failures

### DIFF
--- a/.github/workflows/preview-verification.yml
+++ b/.github/workflows/preview-verification.yml
@@ -339,6 +339,7 @@ jobs:
             --timeout=30 \
             --max-connections=10 \
             --max-connections-per-host=5 \
+            --rate-limit=20 \
             --buffer-size=16384 \
             --exclude=".*mailto:.*" \
             --exclude=".*linkedin\.com.*" \


### PR DESCRIPTION
## Summary

Adds `--rate-limit=20` to the muffet invocation in `preview-verification.yml` to reduce intermittent `verify-preview` failures caused by external hosts (notably **github.com**) returning bursts of `504 Gateway Timeout` mid-scan.

```diff
             --max-connections=10 \
             --max-connections-per-host=5 \
+            --rate-limit=20 \
             --buffer-size=16384 \
```

## Why

A recent run timed out **every** `github.com` URL at once — including rock-solid repos like `google/skywater-pdk` — and took ~9 minutes (vs. the usual ~3-4). That all-one-host-at-once pattern is throttling/availability, not link rot. muffet fires requests as fast as its connection limits allow; a global rate cap smooths the bursts.

## Why not send a GitHub token instead

muffet's `--header` has **no per-host scoping** (confirmed in the [muffet usage docs](https://raviqqe.com/muffet/usage/): `--header` = "Custom headers", with no per-host/auth option). An `Authorization: Bearer <token>` header would therefore be sent to **every** host muffet crawls — including arbitrary external sites — leaking a `pull-requests: write`-scoped token. A token also wouldn't reliably help: muffet fetches `github.com` **HTML pages**, not the rate-limited `api.github.com` API surface. `--rate-limit` needs no secret and cannot leak anything.

## Notes

- `20/s` is a conservative starting point; can be tuned if scans get too slow or failures persist.
- Independent of the in-flight muffet exclude/anchor work in #100 (different lines in the same block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
